### PR TITLE
Chaning port var to integer

### DIFF
--- a/extanalysis.py
+++ b/extanalysis.py
@@ -51,9 +51,9 @@ else:
     host = '127.0.0.1'
 
 if args.port is not None:
-    port = args.port
+    port = int(args.port)
 else:
-    port = '13337'
+    port = 13337
 
 # enable Quiet mode
 if args.quiet:


### PR DESCRIPTION
On my Python 3.8.0 system, I was getting errors due to thge port variable being a string. This addresses that.