### PR TITLE
Add Docker Compose Support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,13 @@ optional arguments:
  docker compose build
  
  docker compose up
+
+ ## Or just:
+ docker compose up --build
  
+ ## To run only for one-time use
+ docker-compose run --rm --build -it -p 13337:13337 extanalysis -h 0.0.0.0
+
  ## To run in the background
  docker compose up -d
  ```

--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ optional arguments:
  docker run --rm -it -p 13337:13337 extanalysis -h 0.0.0.0
  ```
 
+### Using Docker Compose
+
+ ```bash
+ docker compose build
+ 
+ docker compose up
+ 
+ ## To run in the background
+ docker compose up -d
+ ```
 
 ## Python Modules Used:
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ optional arguments:
   --help                Shows this help menu and exits
 ```
 
+## Installing Docker Engine
+
+Use the following [link](https://docs.docker.com/engine/install/)
 
 ## Docker Build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+
+services:
+  extanalysis:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    ports:
+      - "13337:13337"
+    command: -h 0.0.0.0
+    stdin_open: true
+    tty: true


### PR DESCRIPTION
### Summary
This pull request adds Docker Compose support to the ExtAnalysis project and updates the README with relevant instructions for using Docker and Docker Compose.

### Changes
1. Added `docker-compose.yml` to simplify the setup and running of ExtAnalysis using Docker Compose.
2. Updated the README with:
   - New Docker Compose section under "Docker Usage".
   - Detailed instructions on building and running the application using Docker and Docker Compose.

### Motivation
Adding Docker Compose support allows users to set up and run ExtAnalysis using a compose.

### Testing
- Run ` docker compose up --build`
- Run `docker-compose run --rm --build -it -p 13337:13337 extanalysis -h 0.0.0.0`.

### Additional Notes
- Ensure you have Docker and Docker Compose installed before following the instructions in the updated README.
