### PR TITLE
🐛fix: extract extension ID correctly from Chrome Web Store URL for valid downloads

### DIFF
--- a/core/downloader.py
+++ b/core/downloader.py
@@ -97,23 +97,41 @@ class ExtensionDownloader:
 
         return None
 
+    def _extract_chrome_id(self, url: str) -> Optional[str]:
+        """Extract Chrome extension ID from URL."""
+        # Handle both old and new Chrome Web Store URLs
+        if 'chrome.google.com/webstore' in url or 'chromewebstore.google.com/detail' in url:
+            # Split by '/' and get the last part which contains the ID
+            parts = url.rstrip('/').split('/')
+            return parts[-1]
+        # If the input is already an ID, return it directly
+        elif len(url.strip()) == 32:  
+            return url.strip()
+        return None
+
     def download_chrome(self, ext_id: str, name: Optional[str] = None) -> Optional[str]:
         """Download Chrome extension using the updated URL format.
 
         Args:
-            ext_id: The Chrome extension ID
+            ext_id: The Chrome extension ID or URL
             name: Optional name for the saved file
 
         Returns:
             The name of the saved file if successful, None otherwise
         """
-        save_name = name if name else ext_id
+        # Extract extension ID if a URL is provided
+        actual_id = self._extract_chrome_id(ext_id)
+        if not actual_id:
+            core.updatelog('Invalid Chrome extension ID or URL')
+            return None
+
+        save_name = name if name else actual_id
 
         dl_url = (
             "https://clients2.google.com/service/update2/crx?"
             "response=redirect&"
             f"prodversion={self.chrome_version}&"
-            "x=id%3D" + ext_id + "%26installsource%3Dondemand%26uc&"
+            f"x=id%3D{actual_id}%26installsource%3Dondemand%26uc&"
             f"nacl_arch={self.nacl_arch}&"
             "acceptformat=crx2,crx3"
         )

--- a/settings.json
+++ b/settings.json
@@ -1,34 +1,24 @@
 {
-    "virustotal_api": "",
+    "virustotal_api": "72ec46a5ba259fabcda11628d219f9b2b24d299a070581ce0580fbed886d04d0",
     "_comment1": "your virustotal api is needed for scanning files. https://developers.virustotal.com/reference",
-
     "results_directory_path": "",
-    "_comment2":"enter path where you want your results to be saved... keep it empty to use the default reports/ directory",
-
+    "_comment2": "enter path where you want your results to be saved... keep it empty to use the default reports/ directory",
     "lab_directory_path": "",
     "_comment3": "enter path where you want the extensions to be downloaded and extracted. Leave it empty to use the default lab/ directory",
-
     "old_result_directory": "",
     "_comment4": "DO NOT EDIT THIS MANUALLY... UNLESS YOU KNOW WHAT YOU ARE DOING",
-
     "ignore_css": true,
     "_comment5": "set this to false if you want to analyze css files. Disabled by default as css files contain a lot of junk!",
-
     "extract_comments": true,
     "_comment6": "Set it to false if you want to skip extracting comments from files",
-
     "extract_btc_addresses": true,
     "_comment7": "Set this to false if you want to skip extracting bitcoin addresses from files",
-
     "extract_base64_strings": true,
     "_comment8": "Set this to false if you want to skip extracting base64 encoded strings from files",
-
     "extract_email_addresses": true,
     "_comment9": "Set this to false to skip extracting email addresses from files!",
-
     "extract_ipv4_addresses": true,
     "_comment10": "Set this to false if you want to skip extracting IPv4 addresses from files",
-
     "extract_ipv6_addresses": true,
     "_comment11": "set this to false if you want to skip extracting IPv6 addresses from files"
 }

--- a/settings.json
+++ b/settings.json
@@ -1,24 +1,34 @@
 {
-    "virustotal_api": "72ec46a5ba259fabcda11628d219f9b2b24d299a070581ce0580fbed886d04d0",
+    "virustotal_api": "",
     "_comment1": "your virustotal api is needed for scanning files. https://developers.virustotal.com/reference",
+
     "results_directory_path": "",
-    "_comment2": "enter path where you want your results to be saved... keep it empty to use the default reports/ directory",
+    "_comment2":"enter path where you want your results to be saved... keep it empty to use the default reports/ directory",
+
     "lab_directory_path": "",
     "_comment3": "enter path where you want the extensions to be downloaded and extracted. Leave it empty to use the default lab/ directory",
+
     "old_result_directory": "",
     "_comment4": "DO NOT EDIT THIS MANUALLY... UNLESS YOU KNOW WHAT YOU ARE DOING",
+
     "ignore_css": true,
     "_comment5": "set this to false if you want to analyze css files. Disabled by default as css files contain a lot of junk!",
+
     "extract_comments": true,
     "_comment6": "Set it to false if you want to skip extracting comments from files",
+
     "extract_btc_addresses": true,
     "_comment7": "Set this to false if you want to skip extracting bitcoin addresses from files",
+
     "extract_base64_strings": true,
     "_comment8": "Set this to false if you want to skip extracting base64 encoded strings from files",
+
     "extract_email_addresses": true,
     "_comment9": "Set this to false to skip extracting email addresses from files!",
+
     "extract_ipv4_addresses": true,
     "_comment10": "Set this to false if you want to skip extracting IPv4 addresses from files",
+
     "extract_ipv6_addresses": true,
     "_comment11": "set this to false if you want to skip extracting IPv6 addresses from files"
 }


### PR DESCRIPTION
Previously, the download URL was incorrectly appending the entire Chrome Web Store URL
instead of extracting the extension ID. This caused HTTP 404 errors due to an invalid
request format.

Now, the logic correctly parses the extension ID from the given Web Store URL and 
constructs a valid download URL.

Example:
- Input URL: https://chromewebstore.google.com/detail/clockify-time-tracker/pmjeegjhjdlccodhacdgbgfagbpmccpe
- Extracted ID: pmjeegjhjdlccodhacdgbgfagbpmccpe
- Corrected Download URL: https://clients2.google.com/service/update2/crx?response=redirect&prodversion=121.0.0.0&x=id%3Dpmjeegjhjdlccodhacdgbgfagbpmccpe%26installsource%3Dondemand%26uc